### PR TITLE
test: add stub-based tests for conversation_manager, prompt_architect…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,41 @@
 """
 conftest.py — shared fixtures for the RE Assistant test suite.
-
-Fixtures here are available to all test files without explicit import.
 """
-
 import pytest
 import sys
 import types
 
+# ---------------------------------------------------------------------------
+# Clear stub-contaminated modules at collection time (before any test runs)
+# ---------------------------------------------------------------------------
+_STUB_MODULES = [
+    "src.components.system_prompt.prompt_architect",
+    "src.components.system_prompt.prompt_context",
+    "src.components.system_prompt.utils",
+    "src.components.gap_detector",
+    "src.components.srs_coverage",
+    "src.components.domain_discovery.domain_discovery",
+    "src.components.conversation_manager.conversation_manager",
+    "src.components.conversation_manager.llm_provider",
+]
 
-# Session-scoped stub registry
-# Prevents multiple test files from re-registering the same stubs
-# and causing "module already registered" conflicts.
+def pytest_runtest_setup(item):
+    """Clear stubs before every test item so each test gets real modules."""
+    for key in _STUB_MODULES:
+        sys.modules.pop(key, None)
+
+
+def pytest_collection_finish(session):
+    """Clear stubs once after all files are collected."""
+    for key in _STUB_MODULES:
+        sys.modules.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers & Fixtures (unchanged)
+# ---------------------------------------------------------------------------
 
 def _ensure_stub(module_name: str, attrs: dict = None):
-    """Register a stub module if not already present, then patch attrs."""
     if module_name not in sys.modules:
         sys.modules[module_name] = types.ModuleType(module_name)
     if attrs:
@@ -23,11 +44,8 @@ def _ensure_stub(module_name: str, attrs: dict = None):
     return sys.modules[module_name]
 
 
-# Fixtures
-
 @pytest.fixture
 def minimal_state():
-    """Return a bare ConversationState with no domain gate and no turns."""
     from src.components.conversation_state import ConversationState
     state = ConversationState(session_id="test-session-001")
     state.domain_gate = None
@@ -36,47 +54,38 @@ def minimal_state():
 
 @pytest.fixture
 def seeded_gate():
-    """Return a DomainGate seeded with three domains in varying states."""
     from src.components.domain_discovery.domain_gate import DomainGate
     from src.components.domain_discovery.domain_space import DomainSpec
-
     gate = DomainGate(seeded=True)
-
     auth = DomainSpec(label="User Authentication")
     auth.status = "confirmed"
     auth.req_ids = ["FR-001", "FR-002", "FR-003"]
     auth.probe_count = 2
     gate.domains["user_authentication"] = auth
-
     reporting = DomainSpec(label="Reporting")
     reporting.status = "partial"
     reporting.req_ids = ["FR-004"]
     reporting.probe_count = 1
     gate.domains["reporting"] = reporting
-
     legacy = DomainSpec(label="Legacy Module")
     legacy.status = "excluded"
     gate.domains["legacy"] = legacy
-
     return gate
 
 
 @pytest.fixture
 def extractor():
-    """Return a default RequirementExtractor instance."""
     from src.components.requirement_extractor import RequirementExtractor
     return RequirementExtractor(min_text_length=15)
 
 
 @pytest.fixture
 def gap_detector_enabled():
-    """Return a GapDetector with gap detection enabled."""
     from src.components.gap_detector import GapDetector
     return GapDetector(enabled=True)
 
 
 @pytest.fixture
 def gap_detector_disabled():
-    """Return a GapDetector with gap detection disabled."""
     from src.components.gap_detector import GapDetector
     return GapDetector(enabled=False)

--- a/tests/test_x_conversation_manager.py
+++ b/tests/test_x_conversation_manager.py
@@ -1,0 +1,559 @@
+"""
+Tests for src/components/conversation_manager/conversation_manager.py
+
+Uses the real StubProvider — no mocked LLM layer.
+sys.modules stubs are registered before any project import to prevent
+import-chain errors.
+
+Import chain that must be stubbed before importing conversation_manager:
+  conversation_manager.py imports:
+    - src.components.system_prompt.prompt_architect  → PromptArchitect, TaskType
+    - src.components.system_prompt.utils             → PHASE4_SECTIONS
+    - src.components.domain_discovery.domain_discovery → DomainDiscovery, ...
+    - src.components.domain_discovery.domain_gate    → DomainGate
+    - src.components.srs_formatter                   → generate_srs_document
+    - src.components.srs_template                    → SRSTemplate, create_template
+    - src.components.gap_detector                    → GapDetector, create_gap_detector
+    - src.components.requirement_extractor           → RequirementExtractor, create_extractor
+
+  prompt_architect imports prompt_context which imports domain_discovery.utils
+  srs_formatter imports domain_discovery.domain_discovery (NFR_CATEGORIES)
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import Literal
+from unittest.mock import MagicMock
+from enum import Enum
+import pytest
+
+_to_clear = [
+    "src.components.srs_coverage",
+    "src.components.system_prompt.prompt_architect",
+    "src.components.system_prompt.prompt_context",
+    "src.components.system_prompt.utils",
+    "src.components.domain_discovery.domain_discovery",
+    "src.components.conversation_manager.conversation_manager",
+    "src.components.conversation_manager.llm_provider",
+]
+for _key in _to_clear:
+    sys.modules.pop(_key, None)
+
+# ---------------------------------------------------------------------------
+# Build a minimal GapSeverity enum (mirrors real one)
+# ---------------------------------------------------------------------------
+class GapSeverity(str, Enum):
+    CRITICAL  = "critical"
+    IMPORTANT = "important"
+    OPTIONAL  = "optional"
+
+# ---------------------------------------------------------------------------
+# Helper: register a stub module only if not already present
+# ---------------------------------------------------------------------------
+def _ensure_stub(name: str, **attrs):
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    mod = sys.modules[name]
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+# ---------------------------------------------------------------------------
+# domain_discovery.utils — imported by prompt_context, gap_detector, domain_gate
+# ---------------------------------------------------------------------------
+_ensure_stub(
+    "src.components.domain_discovery.utils",
+    NFR_CATEGORIES={
+        "performance":      "Performance",
+        "usability":        "Usability",
+        "security_privacy": "Security & Privacy",
+        "reliability":      "Reliability",
+        "compatibility":    "Compatibility",
+        "maintainability":  "Maintainability",
+        "availability":     "Availability",
+    },
+    COVERAGE_CHECKLIST={},
+    DOMAIN_SUB_DIMENSIONS=["data","actions","constraints","automation","edge_cases"],
+    _DOMAIN_GATE_COVERAGE_FRACTION=0.80,
+    GapSeverity=GapSeverity,
+    STRUCTURAL_CATEGORIES={},
+    MIN_FUNCTIONAL_FOR_NFR=10,
+    NFR_PROBE_HINTS={},
+    # Prompt template strings that domain_discovery.py imports
+    _SEED_PROMPT="",
+    _RESEED_PROMPT="",
+    _NFR_CLASSIFY_PROMPT="",
+    _SUBDIM_CLASSIFY_PROMPT="",
+    _DOMAIN_MATCH_PROMPT="",
+    _DECOMPOSE_PROMPT="",
+    _PROJECT_NAME_PROMPT="",
+    _COMPLEXITY_PROMPT="",
+    _DOMAIN_TEMPLATE_PROMPT="",
+)
+
+# ---------------------------------------------------------------------------
+# system_prompt.prompt_architect — imported by conversation_manager directly
+# Must expose: PromptArchitect, TaskType, IEEE830_CATEGORIES,
+#              MANDATORY_NFR_CATEGORIES, MIN_FUNCTIONAL_REQS, PHASE4_SECTIONS
+# ---------------------------------------------------------------------------
+TaskType = Literal["elicitation", "srs_only"]
+
+_ensure_stub(
+    "src.components.system_prompt.prompt_architect",
+    PromptArchitect=MagicMock,
+    TaskType=TaskType,
+    IEEE830_CATEGORIES={},
+    MANDATORY_NFR_CATEGORIES=frozenset({
+        "performance","usability","security_privacy",
+        "reliability","compatibility","maintainability","availability",
+    }),
+    MIN_FUNCTIONAL_REQS=10,
+    MIN_NFR_PER_CATEGORY=3,
+    PHASE4_SECTIONS=[],
+)
+
+# ---------------------------------------------------------------------------
+# system_prompt.utils — imported by conversation_manager (PHASE4_SECTIONS)
+# ---------------------------------------------------------------------------
+_ensure_stub(
+    "src.components.system_prompt.utils",
+    PHASE4_SECTIONS=[],
+    MIN_FUNCTIONAL_REQS=10,
+    MIN_NFR_PER_CATEGORY=3,
+    MANDATORY_NFR_CATEGORIES=frozenset({
+        "performance","usability","security_privacy",
+        "reliability","compatibility","maintainability","availability",
+    }),
+    IEEE830_CATEGORIES={},
+    NFR_PROBE_HINTS={},
+    _COMMS_STYLE="",
+    _REQ_FORMAT="",
+    _SEC_FORMAT="",
+    _ELICITATION_FR_ROLE="",
+    _ELICITATION_NFR_ROLE="",
+    _ELICITATION_IEEE_ROLE="",
+    _SRS_ONLY_ROLE="",
+    _PREPROCESS_SYSTEM="",
+    _PREPROCESS_USER="",
+    _SCOPE_PROMPT="",
+    _PERSPECTIVE_PROMPT="",
+    _PRODUCT_FUNCTIONS_DOMAIN_PROMPT="",
+    _USER_CLASSES_PROMPT="",
+    _GENERAL_CONSTRAINTS_PROMPT="",
+    _ASSUMPTIONS_PROMPT="",
+    _INTERFACES_PROMPT="",
+    _CONSTRAINTS_STUB="",
+    _DATABASE_STUB="",
+    _SYSTEM_ROLE="",
+)
+
+# ---------------------------------------------------------------------------
+# Now safe to import real project modules
+# ---------------------------------------------------------------------------
+from src.components.conversation_manager.llm_provider import StubProvider
+from src.components.conversation_manager.conversation_manager import (
+    ConversationManager, MAX_HISTORY_TURNS,
+)
+from src.components.conversation_state import ConversationState, RequirementType
+from src.components.conversation_manager.session_logger import SessionLogger
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_manager(tmp_path, responses=None, gap_enabled=True):
+    provider = StubProvider(responses=responses or ["Stub assistant reply."])
+    return ConversationManager(
+        provider=provider,
+        log_dir=tmp_path / "logs",
+        output_dir=tmp_path / "output",
+        gap_enabled=gap_enabled,
+    )
+
+
+def _make_processed_req(text, req_type="functional",
+                         category="auth", category_label="Authentication"):
+    pr = MagicMock()
+    pr.final_text = text
+    pr.req_type = req_type
+    pr.category = category
+    pr.category_label = category_label
+    return pr
+
+
+# ---------------------------------------------------------------------------
+# MAX_HISTORY_TURNS constant
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_max_history_turns_is_10(self):
+        assert MAX_HISTORY_TURNS == 10
+
+
+# ---------------------------------------------------------------------------
+# ConversationManager initialisation
+# ---------------------------------------------------------------------------
+
+class TestInit:
+    def test_provider_stored(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        assert isinstance(mgr.provider, StubProvider)
+
+    def test_architect_created(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        assert mgr._architect is not None
+
+    def test_gap_detector_created_when_enabled(self, tmp_path):
+        mgr = _make_manager(tmp_path, gap_enabled=True)
+        assert mgr._gap_detector is not None
+
+    def test_domain_discovery_created(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        assert mgr._domain_discovery is not None
+
+    def test_default_temperature(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        assert mgr.temperature == 0.0
+
+    def test_default_task_type(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        assert mgr.task_type == "elicitation"
+
+
+# ---------------------------------------------------------------------------
+# start_session
+# ---------------------------------------------------------------------------
+
+class TestStartSession:
+    def test_returns_four_tuple(self, tmp_path):
+        assert len(_make_manager(tmp_path).start_session()) == 4
+
+    def test_session_id_is_8_chars(self, tmp_path):
+        session_id, _, _, _ = _make_manager(tmp_path).start_session()
+        assert len(session_id) == 8
+
+    def test_session_id_is_string(self, tmp_path):
+        session_id, _, _, _ = _make_manager(tmp_path).start_session()
+        assert isinstance(session_id, str)
+
+    def test_state_is_conversation_state(self, tmp_path):
+        _, state, _, _ = _make_manager(tmp_path).start_session()
+        assert isinstance(state, ConversationState)
+
+    def test_state_session_id_matches(self, tmp_path):
+        session_id, state, _, _ = _make_manager(tmp_path).start_session()
+        assert state.session_id == session_id
+
+    def test_logger_is_session_logger(self, tmp_path):
+        _, _, logger, _ = _make_manager(tmp_path).start_session()
+        assert isinstance(logger, SessionLogger)
+
+    def test_log_dir_created(self, tmp_path):
+        _make_manager(tmp_path).start_session()
+        assert (tmp_path / "logs").exists()
+
+    def test_session_start_logged_to_file(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, _, logger, _ = mgr.start_session()
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        assert any(e["event_type"] == "session_start" for e in data)
+
+    def test_session_start_contains_model_name(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, _, logger, _ = mgr.start_session()
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        start = next(e for e in data if e["event_type"] == "session_start")
+        assert start["data"]["model"] == "stub-provider-v1"
+
+    def test_unique_session_ids(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        ids = [mgr.start_session()[0] for _ in range(5)]
+        assert len(set(ids)) == 5
+
+    def test_srs_template_not_none(self, tmp_path):
+        _, _, _, template = _make_manager(tmp_path).start_session()
+        assert template is not None
+
+    def test_domain_gate_set_on_state(self, tmp_path):
+        _, state, _, _ = _make_manager(tmp_path).start_session()
+        assert state.domain_gate is not None
+
+
+# ---------------------------------------------------------------------------
+# send_turn
+# ---------------------------------------------------------------------------
+
+class TestSendTurn:
+    def _setup(self, tmp_path, responses=None):
+        mgr = _make_manager(tmp_path, responses=responses or ["What would you like to build?"])
+        _, state, logger, _ = mgr.start_session()
+        return mgr, state, logger
+
+    def test_returns_string(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        assert isinstance(mgr.send_turn("I want to build a library system.", state, logger), str)
+
+    def test_returns_stub_response(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path, responses=["Who are the primary users?"])
+        result = mgr.send_turn("I want to build a library system.", state, logger)
+        assert result == "Who are the primary users?"
+
+    def test_turn_recorded_in_state(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        mgr.send_turn("Hello.", state, logger)
+        assert state.turn_count == 1
+
+    def test_multiple_turns_accumulate(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path, responses=["A","B","C"])
+        for msg in ["One.", "Two.", "Three."]:
+            mgr.send_turn(msg, state, logger)
+        assert state.turn_count == 3
+
+    def test_turn_logged_to_file(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        mgr.send_turn("Some message.", state, logger)
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        assert any(e["event_type"] == "turn" for e in data)
+
+    def test_user_message_in_log(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        mgr.send_turn("I need a booking system.", state, logger)
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        turn = next(e for e in data if e["event_type"] == "turn")
+        assert "booking system" in turn["data"]["user_message"]
+
+    def test_assistant_response_in_log(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path, responses=["What features do you need?"])
+        mgr.send_turn("I need a booking system.", state, logger)
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        turn = next(e for e in data if e["event_type"] == "turn")
+        assert "What features" in turn["data"]["assistant_message"]
+
+    def test_llm_error_raises_runtime_error(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        mgr.provider = MagicMock()
+        mgr.provider.chat.side_effect = Exception("Network timeout")
+        with pytest.raises(RuntimeError, match="LLM API error"):
+            mgr.send_turn("Hello", state, logger)
+
+    def test_history_trimmed_to_max_turns(self, tmp_path):
+        responses = [f"Reply {i}" for i in range(25)]
+        mgr = _make_manager(tmp_path, responses=responses)
+        _, state, logger, _ = mgr.start_session()
+        captured = {}
+        real_chat = mgr.provider.chat
+
+        def spy(system_message, messages, temperature=0.0):
+            captured["messages"] = messages
+            return real_chat(system_message, messages, temperature)
+
+        mgr.provider.chat = spy
+        for i in range(15):
+            mgr.send_turn(f"Turn {i}", state, logger)
+        assert len(captured.get("messages", [])) <= MAX_HISTORY_TURNS * 2 + 1
+
+    def test_srs_template_updated(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        mgr._srs_template = MagicMock()
+        mgr.send_turn("I need a hospital system.", state, logger)
+        mgr._srs_template.update_from_requirements.assert_called()
+
+    def test_gap_detector_called(self, tmp_path):
+        mgr, state, logger = self._setup(tmp_path)
+        mgr._gap_detector.analyse = MagicMock(return_value=None)
+        mgr.send_turn("Message.", state, logger)
+        mgr._gap_detector.analyse.assert_called_once_with(state)
+
+
+# ---------------------------------------------------------------------------
+# inject_requirements — integration with real state
+# ---------------------------------------------------------------------------
+
+class TestInjectRequirements:
+    def test_returns_count_of_injected(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        # Use clearly distinct texts so Jaccard similarity stays well below 0.7
+        reqs = [
+            _make_processed_req("The system shall allow users to log in via email."),
+            _make_processed_req("Administrators shall generate monthly billing invoices."),
+            _make_processed_req("The platform shall send push notifications to mobile devices."),
+        ]
+        assert mgr.inject_requirements(reqs, state, logger) == 3
+
+    def test_requirements_added_to_state(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements(
+            [_make_processed_req("The system shall allow users to log in.")], state, logger)
+        assert state.functional_count == 1
+
+    def test_deduplicates_near_identical(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        text = "The system shall authenticate users via password"
+        count = mgr.inject_requirements(
+            [_make_processed_req(text), _make_processed_req(text)], state, logger)
+        assert count == 1
+
+    def test_functional_type_mapped(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements(
+            [_make_processed_req("FR req", req_type="functional")], state, logger)
+        assert next(iter(state.requirements.values())).req_type == RequirementType.FUNCTIONAL
+
+    def test_non_functional_type_mapped(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements(
+            [_make_processed_req("NFR req", req_type="non_functional",
+                                  category="performance")], state, logger)
+        assert next(iter(state.requirements.values())).req_type == RequirementType.NON_FUNCTIONAL
+
+    def test_constraint_type_mapped(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements(
+            [_make_processed_req("Must use PostgreSQL.", req_type="constraint")], state, logger)
+        assert next(iter(state.requirements.values())).req_type == RequirementType.CONSTRAINT
+
+    def test_source_is_uploaded(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements([_make_processed_req("A requirement.")], state, logger)
+        assert next(iter(state.requirements.values())).source == "uploaded"
+
+    def test_nfr_coverage_incremented(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements(
+            [_make_processed_req("Response < 1s.", req_type="non_functional",
+                                  category="performance")], state, logger)
+        assert state.nfr_coverage.get("performance", 0) == 1
+
+    def test_empty_list_returns_zero(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        assert mgr.inject_requirements([], state, logger) == 0
+
+    def test_event_logged_to_file(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        _, state, logger, _ = mgr.start_session()
+        mgr.inject_requirements([_make_processed_req("Some req.")], state, logger)
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        assert any(e["event_type"] == "requirements_injected" for e in data)
+
+
+# ---------------------------------------------------------------------------
+# _run_smart_check
+# ---------------------------------------------------------------------------
+
+class TestRunSmartCheck:
+    def _ext(self, texts):
+        return [MagicMock(text=t, req_type="functional", category="general") for t in texts]
+
+    def test_empty_list_unchanged(self, tmp_path):
+        assert _make_manager(tmp_path)._run_smart_check([], "msg") == []
+
+    def test_rewrite_applied(self, tmp_path):
+        import json as _json
+        mgr = _make_manager(tmp_path)
+        extracted = self._ext(["The system shall be fast"])
+        resp = _json.dumps([{
+            "original": "The system shall be fast",
+            "final": "The system shall respond within 200ms for 95% of requests",
+            "smart_score": 4, "rewritten": True,
+            "specific": True, "measurable": True,
+            "testable": True, "unambiguous": True, "relevant": True,
+        }])
+        mgr.provider = StubProvider(responses=[resp])
+        assert "200ms" in mgr._run_smart_check(extracted, "msg")[0].text
+
+    def test_no_rewrite_when_flag_false(self, tmp_path):
+        import json as _json
+        mgr = _make_manager(tmp_path)
+        original = "Users must log in with email and password"
+        extracted = self._ext([original])
+        resp = _json.dumps([{
+            "original": original, "final": original,
+            "smart_score": 5, "rewritten": False,
+            "specific": True, "measurable": True,
+            "testable": True, "unambiguous": True, "relevant": True,
+        }])
+        mgr.provider = StubProvider(responses=[resp])
+        assert mgr._run_smart_check(extracted, "msg")[0].text == original
+
+    def test_count_mismatch_returns_original(self, tmp_path):
+        import json as _json
+        mgr = _make_manager(tmp_path)
+        extracted = self._ext(["req1", "req2"])
+        resp = _json.dumps([{"original": "req1", "final": "req1",
+                              "smart_score": 3, "rewritten": False}])
+        mgr.provider = StubProvider(responses=[resp])
+        assert len(mgr._run_smart_check(extracted, "msg")) == 2
+
+    def test_invalid_json_returns_original(self, tmp_path):
+        mgr = _make_manager(tmp_path)
+        extracted = self._ext(["some requirement"])
+        mgr.provider = StubProvider(responses=["not json"])
+        assert mgr._run_smart_check(extracted, "msg")[0].text == "some requirement"
+
+    def test_smart_score_set(self, tmp_path):
+        import json as _json
+        mgr = _make_manager(tmp_path)
+        extracted = self._ext(["some req"])
+        resp = _json.dumps([{
+            "original": "some req", "final": "some req",
+            "smart_score": 4, "rewritten": False,
+            "specific": True, "measurable": True,
+            "testable": True, "unambiguous": True, "relevant": True,
+        }])
+        mgr.provider = StubProvider(responses=[resp])
+        assert mgr._run_smart_check(extracted, "msg")[0].smart_score == 4
+
+
+# ---------------------------------------------------------------------------
+# Full end-to-end conversation flow
+# ---------------------------------------------------------------------------
+
+class TestFullFlow:
+    def test_start_and_send_turn(self, tmp_path):
+        mgr = _make_manager(tmp_path, responses=["Great! Who are the primary users?"])
+        session_id, state, logger, _ = mgr.start_session()
+        response = mgr.send_turn("I want to build a library management system.", state, logger)
+        assert isinstance(response, str) and len(response) > 0
+        data = json.loads(logger.get_log_path().read_text(encoding="utf-8"))
+        types_ = [e["event_type"] for e in data]
+        assert "session_start" in types_ and "turn" in types_
+
+    def test_project_name_extracted_on_first_turn(self, tmp_path):
+        mgr = _make_manager(tmp_path, responses=["Tell me more."])
+        _, state, logger, _ = mgr.start_session()
+        mgr.send_turn("I am building a SmartHome System.", state, logger)
+        assert state.project_name != "Unknown Project"
+
+    def test_stub_responses_cycle(self, tmp_path):
+        mgr = _make_manager(tmp_path, responses=["Alpha", "Beta"])
+
+        mgr._run_smart_check = lambda extracted, msg: extracted
+
+        _, state, logger, _ = mgr.start_session()
+
+        r = [mgr.send_turn(f"Turn {i}", state, logger) for i in range(4)]
+
+        # Ensure cycling pattern regardless of offset
+        unique = list(dict.fromkeys(r))  # preserves order
+        assert set(unique) == {"Alpha", "Beta"}
+        assert len(unique) == 2
+
+    def test_message_history_grows(self, tmp_path):
+        mgr = _make_manager(tmp_path, responses=["A", "B", "C"])
+        _, state, logger, _ = mgr.start_session()
+        for msg in ["One", "Two", "Three"]:
+            mgr.send_turn(msg, state, logger)
+        assert len(state.get_message_history()) == 6

--- a/tests/test_x_prompt_architect.py
+++ b/tests/test_x_prompt_architect.py
@@ -1,0 +1,367 @@
+"""
+Tests for src/components/system_prompt/prompt_architect.py
+
+Uses the real PromptArchitect — no MagicMock stub for this module.
+sys.modules stubs are registered before any project import to prevent
+import-chain errors.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+import pytest
+
+# ---------------------------------------------------------------------------
+# Safe module cache clearing — must happen before imports
+# Clears any MagicMock stub for prompt_architect registered by earlier tests
+# Uses pop() instead of del to avoid KeyError if key is absent
+# ---------------------------------------------------------------------------
+_to_clear = [
+    "src.components.srs_coverage",
+    "src.components.system_prompt.prompt_architect",
+    "src.components.system_prompt.prompt_context",
+    "src.components.system_prompt.utils",
+    "src.components.domain_discovery.domain_discovery",
+    "src.components.conversation_manager.conversation_manager",
+    "src.components.conversation_manager.llm_provider",
+]
+for _key in _to_clear:
+    sys.modules.pop(_key, None)
+# ---------------------------------------------------------------------------
+# sys.modules stubs — must come BEFORE any project import
+# ---------------------------------------------------------------------------
+
+def _stub_module(name: str, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+if "src.components.domain_discovery.utils" not in sys.modules:
+    _stub_module(
+        "src.components.domain_discovery.utils",
+        NFR_CATEGORIES={
+            "performance": "Performance",
+            "usability": "Usability",
+            "security_privacy": "Security & Privacy",
+            "reliability": "Reliability",
+            "compatibility": "Compatibility",
+            "maintainability": "Maintainability",
+            "availability": "Availability",
+        },
+        COVERAGE_CHECKLIST={},
+        DOMAIN_SUB_DIMENSIONS=["data", "actions", "constraints", "automation", "edge_cases"],
+        _DOMAIN_GATE_COVERAGE_FRACTION=0.80,
+        GapSeverity=MagicMock(),
+        STRUCTURAL_CATEGORIES={},
+        MIN_FUNCTIONAL_FOR_NFR=10,
+        _SEED_PROMPT="",
+        _RESEED_PROMPT="",
+        _NFR_CLASSIFY_PROMPT="",
+        _SUBDIM_CLASSIFY_PROMPT="",
+        _DOMAIN_MATCH_PROMPT="",
+        _DECOMPOSE_PROMPT="",
+        _PROJECT_NAME_PROMPT="",
+        _COMPLEXITY_PROMPT="",
+        _DOMAIN_TEMPLATE_PROMPT="",
+        NFR_PROBE_HINTS={},
+    )
+
+# ---------------------------------------------------------------------------
+# Now safe to import the REAL project modules
+# ---------------------------------------------------------------------------
+
+from src.components.conversation_manager.llm_provider import StubProvider
+from src.components.system_prompt.prompt_architect import PromptArchitect
+from src.components.system_prompt.utils import (
+    IEEE830_CATEGORIES, MANDATORY_NFR_CATEGORIES, MIN_FUNCTIONAL_REQS,
+    MIN_NFR_PER_CATEGORY, PHASE4_SECTIONS,
+)
+from src.components.system_prompt.prompt_context import determine_elicitation_phase
+from src.components.conversation_state import ConversationState, RequirementType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _state(functional=0, nfr_coverage=None, phase4_covered=None,
+           domain_gate=None, project_name="TestProject"):
+    s = ConversationState(session_id="s1", project_name=project_name)
+    s.domain_gate = domain_gate
+    if nfr_coverage:
+        s.nfr_coverage = nfr_coverage
+    if phase4_covered:
+        s.phase4_sections_covered = phase4_covered
+    s.add_turn("setup", "ok")
+    for i in range(functional):
+        s.add_requirement(RequirementType.FUNCTIONAL,
+                          f"The system shall do task {i} within 2 seconds.", "auth")
+    return s
+
+
+def _satisfied_gate():
+    gate = MagicMock()
+    gate.is_satisfied = True
+    gate.seeded = True
+    gate.domains = {}
+    gate.done_count = 0
+    gate.total = 0
+    return gate
+
+
+def _unsatisfied_gate():
+    gate = MagicMock()
+    gate.is_satisfied = False
+    gate.seeded = True
+    gate.domains = {}
+    gate.done_count = 0
+    gate.total = 0
+    return gate
+
+
+def _nfr_met():
+    return {k: MIN_NFR_PER_CATEGORY for k in MANDATORY_NFR_CATEGORIES}
+
+
+def _all_phase4():
+    return {sid for sid, *_ in PHASE4_SECTIONS}
+
+
+# ---------------------------------------------------------------------------
+# PromptArchitect — defaults and initialisation
+# ---------------------------------------------------------------------------
+
+class TestDefaults:
+    def test_default_task_type(self):
+        assert PromptArchitect().task_type == "elicitation"
+
+    def test_default_extra_context_empty(self):
+        assert PromptArchitect().extra_context == ""
+
+    def test_custom_task_type(self):
+        assert PromptArchitect(task_type="srs_only").task_type == "srs_only"
+
+    def test_custom_extra_context(self):
+        a = PromptArchitect(extra_context="Extra info")
+        assert a.extra_context == "Extra info"
+
+
+# ---------------------------------------------------------------------------
+# build_system_message — FR phase
+# ---------------------------------------------------------------------------
+
+class TestBuildSystemMessageFRPhase:
+    def test_returns_string(self):
+        a = PromptArchitect()
+        s = _state(domain_gate=_unsatisfied_gate())
+        result = a.build_system_message(s)
+        assert isinstance(result, str)
+
+    def test_contains_role_header(self):
+        a = PromptArchitect()
+        s = _state(domain_gate=_unsatisfied_gate())
+        result = a.build_system_message(s)
+        assert "ROLE" in result.upper()
+
+    def test_contains_project_name(self):
+        a = PromptArchitect()
+        s = _state(domain_gate=_unsatisfied_gate(), project_name="LibrarySystem")
+        result = a.build_system_message(s)
+        assert "LibrarySystem" in result
+
+    def test_fr_phase_label_present(self):
+        a = PromptArchitect()
+        s = _state(domain_gate=_unsatisfied_gate())
+        result = a.build_system_message(s)
+        assert "PHASE 1" in result or "ELICIT" in result.upper()
+
+    def test_extra_context_injected(self):
+        a = PromptArchitect(extra_context="IMPORTANT: Focus on security.")
+        s = _state(domain_gate=_unsatisfied_gate())
+        result = a.build_system_message(s)
+        assert "IMPORTANT: Focus on security." in result
+
+    def test_no_extra_context_section_when_empty(self):
+        a = PromptArchitect(extra_context="")
+        s = _state(domain_gate=_unsatisfied_gate())
+        result = a.build_system_message(s)
+        assert "ADDITIONAL CONTEXT" not in result
+
+
+# ---------------------------------------------------------------------------
+# build_system_message — NFR phase
+# ---------------------------------------------------------------------------
+
+class TestBuildSystemMessageNFRPhase:
+    def test_nfr_phase_label_present(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(), nfr_coverage={})
+        result = a.build_system_message(s)
+        assert "PHASE 2" in result or "NON-FUNCTIONAL" in result.upper()
+
+    def test_nfr_context_in_message(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(), nfr_coverage={})
+        result = a.build_system_message(s)
+        assert "Performance" in result or "NFR" in result.upper()
+
+    def test_returns_string(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(), nfr_coverage={})
+        assert isinstance(a.build_system_message(s), str)
+
+
+# ---------------------------------------------------------------------------
+# build_system_message — IEEE phase
+# ---------------------------------------------------------------------------
+
+class TestBuildSystemMessageIEEEPhase:
+    def test_ieee_phase_label_present(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(),
+                   nfr_coverage=_nfr_met(), phase4_covered=set())
+        result = a.build_system_message(s)
+        assert "PHASE 3" in result or "IEEE" in result.upper()
+
+    def test_returns_string(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(),
+                   nfr_coverage=_nfr_met())
+        assert isinstance(a.build_system_message(s), str)
+
+
+# ---------------------------------------------------------------------------
+# build_system_message — srs_only task type
+# ---------------------------------------------------------------------------
+
+class TestBuildSRSOnlyMessage:
+    def test_contains_srs_task_label(self):
+        a = PromptArchitect(task_type="srs_only")
+        result = a.build_system_message(_state())
+        assert "SRS" in result.upper()
+
+    def test_contains_role_header(self):
+        a = PromptArchitect(task_type="srs_only")
+        result = a.build_system_message(_state())
+        assert "ROLE" in result.upper()
+
+    def test_returns_string(self):
+        a = PromptArchitect(task_type="srs_only")
+        assert isinstance(a.build_system_message(_state()), str)
+
+    def test_requirements_section_present_when_reqs_exist(self):
+        a = PromptArchitect(task_type="srs_only")
+        result = a.build_system_message(_state(functional=5))
+        assert "PROVIDED REQUIREMENTS" in result or "REQUIREMENTS" in result
+
+    def test_no_requirements_section_when_empty(self):
+        a = PromptArchitect(task_type="srs_only")
+        s = ConversationState(session_id="s1")
+        s.domain_gate = None
+        result = a.build_system_message(s)
+        assert "PROVIDED REQUIREMENTS" not in result
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+class TestPublicHelpers:
+    def test_get_category_labels_returns_dict(self):
+        assert isinstance(PromptArchitect().get_category_labels(), dict)
+
+    def test_get_category_labels_matches_ieee830(self):
+        assert PromptArchitect().get_category_labels() == dict(IEEE830_CATEGORIES)
+
+    def test_get_category_labels_is_copy(self):
+        a = PromptArchitect()
+        labels = a.get_category_labels()
+        labels["injected"] = "bad"
+        assert "injected" not in a.get_category_labels()
+
+    def test_get_mandatory_nfr_categories(self):
+        result = PromptArchitect().get_mandatory_nfr_categories()
+        assert isinstance(result, frozenset)
+        assert result == MANDATORY_NFR_CATEGORIES
+
+    def test_get_min_functional_reqs(self):
+        assert PromptArchitect().get_min_functional_reqs() == MIN_FUNCTIONAL_REQS
+
+    def test_is_srs_permitted_true(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(),
+                   nfr_coverage=_nfr_met(), phase4_covered=_all_phase4())
+        assert a.is_srs_generation_permitted(s) is True
+
+    def test_is_srs_permitted_false_insufficient_fr(self):
+        a = PromptArchitect()
+        s = _state(functional=0, domain_gate=None)
+        assert a.is_srs_generation_permitted(s) is False
+
+    def test_is_srs_permitted_false_unsatisfied_gate(self):
+        a = PromptArchitect()
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_unsatisfied_gate(),
+                   nfr_coverage=_nfr_met(), phase4_covered=_all_phase4())
+        assert a.is_srs_generation_permitted(s) is False
+
+
+# ---------------------------------------------------------------------------
+# get_current_phase
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentPhase:
+    def test_srs_only_always_ieee(self):
+        assert PromptArchitect(task_type="srs_only").get_current_phase(_state()) == "ieee"
+
+    def test_elicitation_fr_when_gate_not_satisfied(self):
+        a = PromptArchitect(task_type="elicitation")
+        assert a.get_current_phase(_state(domain_gate=_unsatisfied_gate())) == "fr"
+
+    def test_elicitation_nfr_when_gate_satisfied_no_nfr(self):
+        a = PromptArchitect(task_type="elicitation")
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(), nfr_coverage={})
+        assert a.get_current_phase(s) == "nfr"
+
+    def test_elicitation_ieee_when_all_satisfied(self):
+        a = PromptArchitect(task_type="elicitation")
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(),
+                   nfr_coverage=_nfr_met())
+        assert a.get_current_phase(s) == "ieee"
+
+
+# ---------------------------------------------------------------------------
+# determine_elicitation_phase (direct)
+# ---------------------------------------------------------------------------
+
+class TestDetermineElicitationPhase:
+    def test_fr_when_gate_none_and_no_nfr(self):
+        s = _state(domain_gate=None, nfr_coverage={})
+        assert determine_elicitation_phase(s) == "nfr"
+
+    def test_fr_when_gate_not_satisfied(self):
+        s = _state(domain_gate=_unsatisfied_gate())
+        assert determine_elicitation_phase(s) == "fr"
+
+    def test_nfr_when_gate_satisfied_nfr_empty(self):
+        s = _state(domain_gate=_satisfied_gate(), nfr_coverage={})
+        assert determine_elicitation_phase(s) == "nfr"
+
+    def test_ieee_when_all_gates_pass(self):
+        s = _state(functional=MIN_FUNCTIONAL_REQS, domain_gate=_satisfied_gate(),
+                   nfr_coverage=_nfr_met())
+        assert determine_elicitation_phase(s) == "ieee"
+
+    def test_nfr_when_one_category_short(self):
+        coverage = _nfr_met()
+        first = next(iter(MANDATORY_NFR_CATEGORIES))
+        coverage[first] = MIN_NFR_PER_CATEGORY - 1
+        s = _state(domain_gate=_satisfied_gate(), nfr_coverage=coverage)
+        assert determine_elicitation_phase(s) == "nfr"
+
+    def test_gate_none_treated_as_domain_ok(self):
+        s = _state(domain_gate=None, nfr_coverage=_nfr_met())
+        assert determine_elicitation_phase(s) == "ieee"

--- a/tests/test_x_srs_coverage.py
+++ b/tests/test_x_srs_coverage.py
@@ -1,0 +1,605 @@
+"""
+Tests for src/components/srs_coverage.py
+
+Uses the real StubProvider for LLM calls inside SRSCoverageEnricher.
+sys.modules stubs are registered before any project import following
+the same pattern as test_gap_detector.py and test_prompt_architect.py.
+
+Import chain:
+  srs_coverage.py imports:
+    - src.components.conversation_state      (RequirementType)
+    - src.components.srs_template            (UserClass)
+    - src.components.system_prompt.utils     (prompts)
+  srs_formatter.py (imported by srs_template tests etc.) imports:
+    - src.components.system_prompt.prompt_architect (IEEE830_CATEGORIES, ...)
+    - src.components.domain_discovery.domain_discovery (NFR_CATEGORIES)
+"""
+from __future__ import annotations
+
+import sys
+import types
+from enum import Enum
+from typing import Literal
+from unittest.mock import MagicMock
+import pytest
+
+_to_clear = [
+    "src.components.srs_coverage",
+    "src.components.system_prompt.prompt_architect",
+    "src.components.system_prompt.prompt_context",
+    "src.components.system_prompt.utils",
+    "src.components.domain_discovery.domain_discovery",
+    "src.components.conversation_manager.conversation_manager",
+    "src.components.conversation_manager.llm_provider",
+]
+for _key in _to_clear:
+    sys.modules.pop(_key, None)
+
+# ---------------------------------------------------------------------------
+# GapSeverity (mirrors real enum, needed by gap_detector stub)
+# ---------------------------------------------------------------------------
+class GapSeverity(str, Enum):
+    CRITICAL  = "critical"
+    IMPORTANT = "important"
+    OPTIONAL  = "optional"
+
+# ---------------------------------------------------------------------------
+# Helper: register stub only if not already present, always update attrs
+# ---------------------------------------------------------------------------
+def _ensure_stub(name: str, **attrs):
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    mod = sys.modules[name]
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+# ---------------------------------------------------------------------------
+# domain_discovery.utils
+# ---------------------------------------------------------------------------
+_ensure_stub(
+    "src.components.domain_discovery.utils",
+    NFR_CATEGORIES={
+        "performance":      "Performance",
+        "usability":        "Usability",
+        "security_privacy": "Security & Privacy",
+        "reliability":      "Reliability",
+        "compatibility":    "Compatibility",
+        "maintainability":  "Maintainability",
+        "availability":     "Availability",
+    },
+    COVERAGE_CHECKLIST={},
+    DOMAIN_SUB_DIMENSIONS=["data","actions","constraints","automation","edge_cases"],
+    _DOMAIN_GATE_COVERAGE_FRACTION=0.80,
+    GapSeverity=GapSeverity,
+    STRUCTURAL_CATEGORIES={},
+    MIN_FUNCTIONAL_FOR_NFR=10,
+    NFR_PROBE_HINTS={},
+    _SEED_PROMPT="",
+    _RESEED_PROMPT="",
+    _NFR_CLASSIFY_PROMPT="",
+    _SUBDIM_CLASSIFY_PROMPT="",
+    _DOMAIN_MATCH_PROMPT="",
+    _DECOMPOSE_PROMPT="",
+    _PROJECT_NAME_PROMPT="",
+    _COMPLEXITY_PROMPT="",
+    _DOMAIN_TEMPLATE_PROMPT="",
+)
+
+# ---------------------------------------------------------------------------
+# system_prompt.prompt_architect (needed by srs_formatter and gap_detector)
+# ---------------------------------------------------------------------------
+TaskType = Literal["elicitation", "srs_only"]
+
+_ensure_stub(
+    "src.components.system_prompt.prompt_architect",
+    PromptArchitect=MagicMock,
+    TaskType=TaskType,
+    IEEE830_CATEGORIES={},
+    MANDATORY_NFR_CATEGORIES=frozenset({
+        "performance","usability","security_privacy",
+        "reliability","compatibility","maintainability","availability",
+    }),
+    MIN_FUNCTIONAL_REQS=10,
+    MIN_NFR_PER_CATEGORY=3,
+    PHASE4_SECTIONS=[],
+)
+
+# ---------------------------------------------------------------------------
+# system_prompt.utils (imported by srs_coverage directly)
+# ---------------------------------------------------------------------------
+_ensure_stub(
+    "src.components.system_prompt.utils",
+    PHASE4_SECTIONS=[],
+    MIN_FUNCTIONAL_REQS=10,
+    MIN_NFR_PER_CATEGORY=3,
+    MANDATORY_NFR_CATEGORIES=frozenset({
+        "performance","usability","security_privacy",
+        "reliability","compatibility","maintainability","availability",
+    }),
+    IEEE830_CATEGORIES={},
+    NFR_PROBE_HINTS={},
+    _COMMS_STYLE="",
+    _REQ_FORMAT="",
+    _SEC_FORMAT="",
+    _ELICITATION_FR_ROLE="",
+    _ELICITATION_NFR_ROLE="",
+    _ELICITATION_IEEE_ROLE="",
+    _SRS_ONLY_ROLE="",
+    _PREPROCESS_SYSTEM="",
+    _PREPROCESS_USER="",
+    _SCOPE_PROMPT="",
+    _PERSPECTIVE_PROMPT="",
+    _PRODUCT_FUNCTIONS_DOMAIN_PROMPT="",
+    _USER_CLASSES_PROMPT="",
+    _GENERAL_CONSTRAINTS_PROMPT="",
+    _ASSUMPTIONS_PROMPT="",
+    _INTERFACES_PROMPT="",
+    _CONSTRAINTS_STUB="",
+    _DATABASE_STUB="[ARCHITECT REVIEW REQUIRED] Implied data requirements must be reviewed.",
+    _SYSTEM_ROLE="",
+)
+
+# ---------------------------------------------------------------------------
+# Now safe to import project modules
+# ---------------------------------------------------------------------------
+from src.components.conversation_manager.llm_provider import StubProvider
+from src.components.srs_coverage import (
+    _reqs_by_category,
+    _all_reqs_text,
+    _fr_list_text,
+    _user_turns_text,
+    _exclusions_text,
+    _domain_summary,
+    _implied_data_reqs,
+    _implied_data_reqs_stub,
+    render_section2_extras,
+    render_section35_stub,
+    SRSCoverageEnricher,
+    create_enricher,
+)
+from src.components.conversation_state import ConversationState, RequirementType
+from src.components.srs_template import SRSTemplate, UserClass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _req(req_id, text, req_type=RequirementType.FUNCTIONAL,
+         category="auth", domain_key=""):
+    r = MagicMock()
+    r.req_id = req_id
+    r.text = text
+
+    # Dummy req_type that behaves like an Enum
+    dummy_type = MagicMock()
+    dummy_type.value = req_type.value
+
+    # ✅ Make equality checks work (critical)
+    dummy_type.__eq__.side_effect = lambda other: other == req_type
+
+    r.req_type = dummy_type
+    r.category = category
+    r.domain_key = domain_key
+    return r
+
+def _state(reqs=None, turns=None, project_name="TestProject",
+           srs_section_content=None, domain_gate=None):
+    s = MagicMock()
+    s.project_name = project_name
+    s.requirements = reqs or {}
+    s.turns = turns or []
+    s.srs_section_content = srs_section_content or {}
+    s.domain_gate = domain_gate
+    return s
+
+
+def _turn(turn_id, user_message):
+    t = MagicMock()
+    t.turn_id = turn_id
+    t.user_message = user_message
+    return t
+
+
+def _template():
+    return SRSTemplate(session_id="s1", project_name="TestProject")
+
+
+def _enricher(response="Generated prose content."):
+    """Create an SRSCoverageEnricher backed by a real StubProvider."""
+    return SRSCoverageEnricher(provider=StubProvider(responses=[response]))
+
+
+# ---------------------------------------------------------------------------
+# _reqs_by_category
+# ---------------------------------------------------------------------------
+
+class TestReqsByCategory:
+    def test_matches_category(self):
+        reqs = {"r1": _req("r1", "Login req", category="auth")}
+        assert "Login req" in _reqs_by_category(_state(reqs=reqs), "auth")
+
+    def test_no_match_returns_none_elicited(self):
+        assert "none" in _reqs_by_category(_state(), "auth").lower()
+
+    def test_max_items_cap(self):
+        reqs = {f"r{i}": _req(f"r{i}", f"Req {i}", category="auth") for i in range(10)}
+        result = _reqs_by_category(_state(reqs=reqs), "auth", max_items=3)
+        assert result.count("- [") <= 3
+
+    def test_matches_req_type_value(self):
+        reqs = {"r1": _req("r1", "NFR req",
+                            req_type=RequirementType.NON_FUNCTIONAL, category="perf")}
+        assert "NFR req" in _reqs_by_category(_state(reqs=reqs), "non_functional")
+
+
+# ---------------------------------------------------------------------------
+# _all_reqs_text
+# ---------------------------------------------------------------------------
+
+class TestAllReqsText:
+    def test_includes_req_id_and_category(self):
+        reqs = {"r1": _req("r1", "Some req", category="auth")}
+        result = _all_reqs_text(_state(reqs=reqs))
+        assert "r1" in result and "auth" in result
+
+    def test_max_items_cap(self):
+        reqs = {f"r{i}": _req(f"r{i}", f"Req {i}") for i in range(50)}
+        assert _all_reqs_text(_state(reqs=reqs), max_items=5).count("- [") <= 5
+
+
+# ---------------------------------------------------------------------------
+# _fr_list_text
+# ---------------------------------------------------------------------------
+
+class TestFRListText:
+    def test_only_functional_included(self):
+        reqs = {
+            "fr1": _req("fr1", "FR one", RequirementType.FUNCTIONAL),
+            "nfr1": _req("nfr1", "NFR one", RequirementType.NON_FUNCTIONAL),
+        }
+        result = _fr_list_text(_state(reqs=reqs))
+        assert "FR one" in result and "NFR one" not in result
+
+    def test_empty_returns_empty_string(self):
+        assert _fr_list_text(_state()) == ""
+
+    def test_max_items_cap(self):
+        reqs = {f"r{i}": _req(f"r{i}", f"FR {i}") for i in range(30)}
+        assert _fr_list_text(_state(reqs=reqs), max_items=5).count("- [") <= 5
+
+
+# ---------------------------------------------------------------------------
+# _user_turns_text
+# ---------------------------------------------------------------------------
+
+class TestUserTurnsText:
+    def test_includes_user_message(self):
+        turns = [_turn(1, "I need a login system")]
+        assert "login system" in _user_turns_text(_state(turns=turns))
+
+    def test_max_turns_respected(self):
+        turns = [_turn(i, f"Message {i}") for i in range(20)]
+        assert _user_turns_text(_state(turns=turns), max_turns=3).count("Turn") <= 3
+
+    def test_truncates_long_messages(self):
+        turns = [_turn(1, "X" * 500)]
+        for line in _user_turns_text(_state(turns=turns), max_chars=50).split("\n"):
+            assert len(line) < 200
+
+
+# ---------------------------------------------------------------------------
+# _exclusions_text
+# ---------------------------------------------------------------------------
+
+class TestExclusionsText:
+    def test_detects_shall_not_constraint(self):
+        reqs = {"c1": _req("c1", "The system shall not support batch imports.",
+                            RequirementType.CONSTRAINT)}
+        assert "batch imports" in _exclusions_text(_state(reqs=reqs))
+
+    def test_no_exclusions_returns_note(self):
+        assert "no explicit" in _exclusions_text(_state()).lower()
+
+    def test_functional_not_included(self):
+        reqs = {"f1": _req("f1", "Users can log in", RequirementType.FUNCTIONAL)}
+        assert "log in" not in _exclusions_text(_state(reqs=reqs))
+
+
+# ---------------------------------------------------------------------------
+# _domain_summary
+# ---------------------------------------------------------------------------
+
+class TestDomainSummary:
+    def test_no_gate_returns_general(self):
+        assert "general" in _domain_summary(_state(domain_gate=None)).lower()
+
+    def test_unseeded_gate_returns_general(self):
+        gate = MagicMock(); gate.seeded = False
+        assert "general" in _domain_summary(_state(domain_gate=gate)).lower()
+
+    def test_returns_domain_labels(self):
+        d1 = MagicMock(); d1.label = "Authentication"; d1.status = "confirmed"
+        d2 = MagicMock(); d2.label = "Payments"; d2.status = "confirmed"
+        gate = MagicMock(); gate.seeded = True
+        gate.domains = {"auth": d1, "payment": d2}
+        result = _domain_summary(_state(domain_gate=gate))
+        assert "Authentication" in result and "Payments" in result
+
+    def test_excluded_domains_filtered(self):
+        d = MagicMock(); d.label = "Excluded Feature"; d.status = "excluded"
+        gate = MagicMock(); gate.seeded = True; gate.domains = {"excl": d}
+        assert "Excluded Feature" not in _domain_summary(_state(domain_gate=gate))
+
+
+# ---------------------------------------------------------------------------
+# _implied_data_reqs
+# ---------------------------------------------------------------------------
+
+class TestImpliedDataReqs:
+    def test_finds_keyword_match(self):
+        reqs = {"r1": _req("r1", "The system shall store user profile data.")}
+        assert "r1" in _implied_data_reqs(_state(reqs=reqs))
+
+    def test_no_match_returns_none_identified(self):
+        assert "none" in _implied_data_reqs(_state()).lower()
+
+    def test_caps_at_10(self):
+        reqs = {f"r{i}": _req(f"r{i}", "The system shall store records.") for i in range(20)}
+        assert _implied_data_reqs(_state(reqs=reqs)).count("- [") <= 10
+
+
+# ---------------------------------------------------------------------------
+# _implied_data_reqs_stub
+# ---------------------------------------------------------------------------
+
+class TestImpliedDataReqsStub:
+    def test_contains_architect_review(self):
+        assert "ARCHITECT" in _implied_data_reqs_stub(_state())
+
+    def test_contains_data_keyword(self):
+        result = _implied_data_reqs_stub(_state())
+        assert "data" in result.lower() or "database" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# render_section2_extras
+# ---------------------------------------------------------------------------
+
+class TestRenderSection2Extras:
+    def test_operating_env_sentinel_rendered(self):
+        tmpl = _template()
+        tmpl.section2.general_constraints = ["__operating_environment__Requires Linux 22.04"]
+        lines = []
+        render_section2_extras(lines, tmpl)
+        combined = "\n".join(lines)
+        assert "Operating Environment" in combined and "Linux" in combined
+
+    def test_docs_sentinel_rendered(self):
+        tmpl = _template()
+        tmpl.section2.general_constraints = ["__user_documentation__User manual required"]
+        lines = []
+        render_section2_extras(lines, tmpl)
+        assert "User Documentation" in "\n".join(lines)
+
+    def test_plain_string_skipped(self):
+        tmpl = _template()
+        tmpl.section2.general_constraints = ["Just a plain constraint"]
+        lines = []
+        render_section2_extras(lines, tmpl)
+        assert lines == []
+
+    def test_non_string_skipped(self):
+        tmpl = _template()
+        tmpl.section2.general_constraints = [42, None]  # type: ignore
+        lines = []
+        render_section2_extras(lines, tmpl)
+        assert lines == []
+
+
+# ---------------------------------------------------------------------------
+# render_section35_stub
+# ---------------------------------------------------------------------------
+
+class TestRenderSection35Stub:
+    def test_returns_true_when_stub_present(self):
+        tmpl = _template()
+        tmpl.section1.references.append("DESIGN_CONSTRAINTS_STUB::Some stub content here")
+        lines = []
+        assert render_section35_stub(lines, tmpl) is True
+        assert len(lines) > 0
+
+    def test_returns_false_when_absent(self):
+        tmpl = _template()
+        lines = []
+        assert render_section35_stub(lines, tmpl) is False
+        assert lines == []
+
+    def test_stub_text_written(self):
+        tmpl = _template()
+        tmpl.section1.references.append("DESIGN_CONSTRAINTS_STUB::Architect must review.")
+        lines = []
+        render_section35_stub(lines, tmpl)
+        assert any("Architect" in l for l in lines)
+
+
+# ---------------------------------------------------------------------------
+# SRSCoverageEnricher._call_llm — uses real StubProvider
+# ---------------------------------------------------------------------------
+
+class TestCallLLM:
+    def test_returns_stub_response(self):
+        result = _enricher("This is the generated scope section.")._call_llm("Generate scope.")
+        assert result == "This is the generated scope section."
+
+    def test_strips_whitespace(self):
+        result = _enricher("  content with spaces  ")._call_llm("prompt")
+        assert result == "content with spaces"
+
+    def test_exception_returns_stub_message(self):
+        p = MagicMock(); p.chat.side_effect = RuntimeError("network error")
+        result = SRSCoverageEnricher(provider=p)._call_llm("prompt")
+        assert "GENERATION FAILED" in result or "manually" in result.lower()
+
+    def test_stub_cycles_for_multiple_calls(self):
+        enricher = _enricher("Consistent response.")
+        assert enricher._call_llm("p1") == enricher._call_llm("p2") == "Consistent response."
+
+
+# ---------------------------------------------------------------------------
+# SRSCoverageEnricher.enrich — phase4 content wins
+# ---------------------------------------------------------------------------
+
+class TestEnrichPhase4Priority:
+    def test_scope_uses_phase4_content(self):
+        state = _state(srs_section_content={"1.2": "Phase4 scope content."})
+        tmpl = _template()
+        filled = _enricher("LLM fallback should not appear").enrich(tmpl, state)
+        assert tmpl.section1.scope == "Phase4 scope content."
+        assert filled.get("§1.2 Scope") == "phase4"
+
+    def test_perspective_uses_phase4_content(self):
+        state = _state(srs_section_content={"2.1": "Phase4 perspective."})
+        tmpl = _template()
+        filled = _enricher("LLM").enrich(tmpl, state)
+        assert tmpl.section2.product_perspective == "Phase4 perspective."
+        assert filled.get("§2.1 Product Perspective") == "phase4"
+
+    def test_user_classes_phase4(self):
+        state = _state(srs_section_content={"2.3": "Phase4 user classes."})
+        tmpl = _template()
+        filled = _enricher("LLM").enrich(tmpl, state)
+        assert filled.get("§2.3 User Classes") == "phase4"
+
+    def test_ui_interface_phase4(self):
+        state = _state(srs_section_content={"3.1.1": "Phase4 UI content."})
+        tmpl = _template()
+        filled = _enricher("LLM").enrich(tmpl, state)
+        assert filled.get("§3.1.1 User Interfaces") == "phase4"
+
+    def test_sw_interface_phase4(self):
+        state = _state(srs_section_content={"3.1.3": "Phase4 SW content."})
+        tmpl = _template()
+        filled = _enricher("LLM").enrich(tmpl, state)
+        assert filled.get("§3.1.3 Software Interfaces") == "phase4"
+
+    def test_comm_interface_phase4(self):
+        state = _state(srs_section_content={"3.1.4": "Phase4 Comm content."})
+        tmpl = _template()
+        filled = _enricher("LLM").enrich(tmpl, state)
+        assert filled.get("§3.1.4 Communication Interfaces") == "phase4"
+
+
+# ---------------------------------------------------------------------------
+# SRSCoverageEnricher.enrich — LLM fallback via StubProvider
+# ---------------------------------------------------------------------------
+
+class TestEnrichLLMFallback:
+    def test_scope_llm_synthesis_when_no_phase4(self):
+        state = _state()
+        tmpl = _template()
+        enricher = _enricher("LLM scope content generated here.")
+        filled = enricher.enrich(tmpl, state)
+        assert filled.get("§1.2 Scope") == "llm_synthesis"
+        assert "LLM scope content" in tmpl.section1.scope
+
+    def test_perspective_llm_synthesis(self):
+        state = _state()
+        tmpl = _template()
+        filled = _enricher("Perspective content from LLM.").enrich(tmpl, state)
+        assert filled.get("§2.1 Product Perspective") == "llm_synthesis"
+
+    def test_general_constraints_always_filled(self):
+        state = _state()
+        tmpl = _template()
+        filled = _enricher("1. Constraint A\n2. Constraint B").enrich(tmpl, state)
+        assert "§2.4 General Constraints" in filled
+
+    def test_user_classes_llm_when_no_phase4(self):
+        state = _state()
+        tmpl = _template()
+        filled = _enricher("User classes description.").enrich(tmpl, state)
+        assert "§2.3 User Classes" in filled
+        assert filled["§2.3 User Classes"] == "llm_synthesis"
+
+
+# ---------------------------------------------------------------------------
+# SRSCoverageEnricher.enrich — always-stub sections
+# ---------------------------------------------------------------------------
+
+class TestEnrichAlwaysStub:
+    def test_hardware_interfaces_always_stub(self):
+        state = _state()
+        tmpl = _template()
+        filled = _enricher("llm content").enrich(tmpl, state)
+        assert filled.get("§3.1.2 Hardware Interfaces") == "stub"
+        hw = tmpl.section3.interfaces.hardware_interfaces
+        assert len(hw) > 0 and "ARCHITECT" in hw[0]
+
+    def test_database_always_stub(self):
+        state = _state()
+        tmpl = _template()
+        filled = _enricher("llm content").enrich(tmpl, state)
+        assert filled.get("§3.4 Logical Database Requirements") == "stub"
+        assert len(tmpl.section3.database) > 0
+
+    def test_design_constraints_stub_when_no_con_reqs(self):
+        state = _state()
+        tmpl = _template()
+        filled = _enricher("llm content").enrich(tmpl, state)
+        assert filled.get("§3.5 Design Constraints") == "stub"
+
+
+# ---------------------------------------------------------------------------
+# SRSCoverageEnricher.enrich — idempotent
+# ---------------------------------------------------------------------------
+
+class TestEnrichIdempotent:
+    def test_does_not_overwrite_existing_scope(self):
+        state = _state()
+        tmpl = _template()
+        tmpl.section1.scope = "Already filled scope."
+        _enricher("Should not replace.").enrich(tmpl, state)
+        assert tmpl.section1.scope == "Already filled scope."
+
+    def test_scope_not_in_filled_when_already_set(self):
+        state = _state()
+        tmpl = _template()
+        tmpl.section1.scope = "Existing scope."
+        filled = _enricher("New").enrich(tmpl, state)
+        assert "§1.2 Scope" not in filled
+
+    def test_user_classes_not_overwritten(self):
+        state = _state()
+        tmpl = _template()
+        tmpl.section2.user_classes = [UserClass("Admin", "Manages system")]
+        _enricher("LLM classes").enrich(tmpl, state)
+        assert len(tmpl.section2.user_classes) == 1
+        assert tmpl.section2.user_classes[0].name == "Admin"
+
+    def test_perspective_not_overwritten(self):
+        state = _state()
+        tmpl = _template()
+        tmpl.section2.product_perspective = "Existing perspective."
+        _enricher("New perspective.").enrich(tmpl, state)
+        assert tmpl.section2.product_perspective == "Existing perspective."
+
+
+# ---------------------------------------------------------------------------
+# create_enricher
+# ---------------------------------------------------------------------------
+
+class TestCreateEnricher:
+    def test_returns_instance(self):
+        p = StubProvider()
+        assert isinstance(create_enricher(p), SRSCoverageEnricher)
+
+    def test_provider_stored(self):
+        p = StubProvider()
+        assert create_enricher(p).provider is p
+
+    def test_enricher_can_call_llm(self):
+        p = StubProvider(responses=["Generated content here."])
+        result = create_enricher(p)._call_llm("Some prompt")
+        assert result == "Generated content here."


### PR DESCRIPTION
…, srs_coverage (452 tests total)

- Add test_x_conversation_manager.py: 50 tests using StubProvider
- Add test_x_prompt_architect.py: 38 tests for real PromptArchitect
- Add test_x_srs_coverage.py: 55 tests for SRSCoverageEnricher
- Add pytest.ini to guarantee alphabetical collection order on all devices
- Update conftest.py with module cache clearing helpers